### PR TITLE
Don't change state if already in desired state

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,17 +115,23 @@ class SwitchBotAccessory {
 
   async setOn(value, callback) {
     const humanState = value ? 'on' : 'off';
-    this.log(`Turning ${humanState}...`);
 
-    try {
-      await this.device.turn(value);
-      this.active = value;
-      this.log(`WoHand (${this.device[humanState].macAddress}) was turned ${humanState}`);
+    if (value === this.active) {
+      this.log(`WoHand (${this.device[humanState].macAddress}) was already ${humanState}`);
       callback();
-    } catch (error) {
-      let message = `WoHand (${this.device[humanState].macAddress}) was failed turning ${humanState}`;
-      this.log(message);
-      callback(message);
+    } else {
+      this.log(`Turning ${humanState}...`);
+
+      try {
+        await this.device.turn(value);
+        this.active = value;
+        this.log(`WoHand (${this.device[humanState].macAddress}) was turned ${humanState}`);
+        callback();
+      } catch (error) {
+        let message = `WoHand (${this.device[humanState].macAddress}) was failed turning ${humanState}`;
+        this.log(message);
+        callback(message);
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-switchbot-for-mac",
-  "version": "0.0.8",
+  "version": "0.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
When the switch is in the "on" state, and the user asks Siri to turn the switch "on" again, the plugin should ignore the second command because the switch is already in the correct state. Prior to this change, the second "on" command would incorrectly toggle the switch back to "off." 